### PR TITLE
Handle other find endpoints and do not serve root URL

### DIFF
--- a/find.go
+++ b/find.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
@@ -15,29 +15,57 @@ import (
 func (s *server) find(w http.ResponseWriter, r *http.Request) {
 	combined := make(chan *model.FindResponse, len(s.servers))
 	wg := sync.WaitGroup{}
+
+	// Copy the original request body in case it is a POST batch find request.
+	var rb []byte
+	var err error
+	rb, err = io.ReadAll(r.Body)
+	_ = r.Body.Close()
+	if err != nil {
+		log.Warnw("failed to read original request body", "err", err)
+		return
+	}
+
 	for _, server := range s.servers {
 		wg.Add(1)
 		go func(server *url.URL) {
 			defer wg.Done()
-			r.URL.Host = server.Host
-			r.URL.Scheme = server.Scheme
-			resp, err := s.Client.Get(r.URL.String())
+
+			// Copy the URL from original request and override host/schema to point
+			// to the server.
+			endpoint := *r.URL
+			endpoint.Host = server.Host
+			endpoint.Scheme = server.Scheme
+			log := log.With("backend", endpoint)
+
+			// If body in original request existed, make a reader for it.
+			var body io.Reader
+			if len(rb) > 0 {
+				body = bytes.NewReader(rb)
+			}
+			req, err := http.NewRequest(r.Method, endpoint.String(), body)
 			if err != nil {
-				log.Warnw("failed query", "backend", r.URL, "err", err)
+				log.Warnw("failed to construct query", "err", err)
+				return
+			}
+			req.Header.Set("X-Forwarded-Host", r.Host)
+			resp, err := s.Client.Do(req)
+			if err != nil {
+				log.Warnw("failed query", "err", err)
 				return
 			}
 			defer resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
-				data, err := ioutil.ReadAll(resp.Body)
+				data, err := io.ReadAll(resp.Body)
 				if err != nil {
-					log.Warnw("failed backend read", "backend", r.URL, "err", err)
+					log.Warnw("failed backend read", "err", err)
 					return
 				}
 				providers, err := model.UnmarshalFindResponse(data)
 				if err == nil {
 					combined <- providers
 				} else {
-					log.Warnw("failed backend unmarshal", "backend", r.URL, "err", err)
+					log.Warnw("failed backend unmarshal", "err", err)
 				}
 			}
 		}(server)
@@ -56,7 +84,7 @@ outer:
 		} else {
 			if !bytes.Equal(resp.MultihashResults[0].Multihash, prov.MultihashResults[0].Multihash) {
 				// weird / invalid.
-				log.Warnw("conflicting results", "q", r.URL.Path, "first", resp.MultihashResults[0].Multihash, "secnd", prov.MultihashResults[0].Multihash)
+				log.Warnw("conflicting results", "q", r.URL.Path, "first", resp.MultihashResults[0].Multihash, "second", prov.MultihashResults[0].Multihash)
 
 				httpserver.HandleError(w, fmt.Errorf("conflicting results"), "get")
 				continue


### PR DESCRIPTION
Handle `GET /cid/{cid}` and `POST /multihash` the other two flavours of
storehtinedex find APIs.