### PR TITLE
Fix incorrect `reframe` handler URI

### DIFF
--- a/server.go
+++ b/server.go
@@ -76,7 +76,7 @@ func (s *server) Serve() chan error {
 		close(ec)
 		return ec
 	}
-	mux.HandleFunc("/reframe/", reframe)
+	mux.HandleFunc("/reframe", reframe)
 	mux.Handle("/", s)
 
 	serv := http.Server{


### PR DESCRIPTION
Do not include `/` suffix in reframe handler URI otherwise requests
from the client will not match.