### PR TITLE
Fix a bug in `reframe` path concatenation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/filecoin-shipyard/indexstar
 
-go 1.18
+go 1.19
 
 require (
 	github.com/filecoin-project/storetheindex v0.4.20

--- a/reframe.go
+++ b/reframe.go
@@ -35,8 +35,7 @@ func NewReframeService(backends []*url.URL) (*ReframeService, error) {
 
 	clients := make([]drclient.DelegatedRoutingClient, 0, len(backends))
 	for _, b := range backends {
-		b.Path += "/reframe"
-		endpoint := b.String()
+		endpoint := b.JoinPath("reframe").String()
 		q, err := drproto.New_DelegatedRouting_Client(endpoint, drproto.DelegatedRouting_Client_WithHTTPClient(&httpClient))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
If the configured backend URL ended with `/` the previous join resulted
in invalid reframe URL. This meant that all reframe queries would have
returned empty result.

Go `1.19` adds utilities for safely joining elements to the path URL.
Since indexstar does not need Go `1.18` support, upgrade the module and
take advantage of the new utility to construct the correct path for
remote reframe endpoints.