### PR TITLE
Make HTTP Dialer settings configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,15 +7,20 @@ import (
 )
 
 const (
-	defaultReframeMaxIdleConns              = 100
-	defaultReframeMaxConnsPerHost           = 100
-	defaultReframeMaxIdleConnsPerHost       = 100
-	defaultReframeHttpClientTimeout         = 10 * time.Second
-	defaultServerMaxIdleConns               = 100
-	defaultServerMaxConnsPerHost            = 100
-	defaultServerMaxIdleConnsPerHost        = 100
-	defaultServerHttpClientTimeout          = 10 * time.Second
-	defaultServerMaxRequestBodySize   int64 = 8 << 10 // 8KiB
+	defaultReframeMaxIdleConns        = 100
+	defaultReframeMaxConnsPerHost     = 100
+	defaultReframeMaxIdleConnsPerHost = 100
+	defaultReframeDialerTimeout       = 10 * time.Second
+	defaultReframeDialerKeepAlive     = 15 * time.Second
+	defaultReframeHttpClientTimeout   = 10 * time.Second
+
+	defaultServerMaxIdleConns              = 100
+	defaultServerMaxConnsPerHost           = 100
+	defaultServerMaxIdleConnsPerHost       = 100
+	defaultServerDialerTimeout             = 10 * time.Second
+	defaultServerDialerKeepAlive           = 15 * time.Second
+	defaultServerHttpClientTimeout         = 10 * time.Second
+	defaultServerMaxRequestBodySize  int64 = 8 << 10 // 8KiB
 )
 
 var config struct {
@@ -23,12 +28,16 @@ var config struct {
 		MaxIdleConns        int
 		MaxConnsPerHost     int
 		MaxIdleConnsPerHost int
+		DialerTimeout       time.Duration
+		DialerKeepAlive     time.Duration
 		HttpClientTimeout   time.Duration
 	}
 	Server struct {
 		MaxIdleConns        int
 		MaxConnsPerHost     int
 		MaxIdleConnsPerHost int
+		DialerTimeout       time.Duration
+		DialerKeepAlive     time.Duration
 		HttpClientTimeout   time.Duration
 		MaxRequestBodySize  int64
 	}
@@ -38,10 +47,14 @@ func init() {
 	config.Reframe.MaxIdleConns = getEnvOrDefault[int]("REFRAME_MAX_IDLE_CONNS", defaultReframeMaxIdleConns)
 	config.Reframe.MaxConnsPerHost = getEnvOrDefault[int]("REFRAME_MAX_CONNS_PER_HOST", defaultReframeMaxConnsPerHost)
 	config.Reframe.MaxIdleConnsPerHost = getEnvOrDefault[int]("REFRAME_MAX_IDLE_CONNS_PER_HOST", defaultReframeMaxIdleConnsPerHost)
+	config.Reframe.DialerTimeout = getEnvOrDefault[time.Duration]("REFRAME_DIALER_TIMEOUT", defaultReframeDialerTimeout)
+	config.Reframe.DialerKeepAlive = getEnvOrDefault[time.Duration]("REFRAME_DIALER_KEEP_ALIVE", defaultReframeDialerKeepAlive)
 	config.Reframe.HttpClientTimeout = getEnvOrDefault[time.Duration]("REFRAME_HTTP_CLIENT_TIMEOUT", defaultReframeHttpClientTimeout)
 	config.Server.MaxIdleConns = getEnvOrDefault[int]("SERVER_MAX_IDLE_CONNS", defaultServerMaxIdleConns)
 	config.Server.MaxConnsPerHost = getEnvOrDefault[int]("SERVER_MAX_CONNS_PER_HOST", defaultServerMaxConnsPerHost)
 	config.Server.MaxIdleConnsPerHost = getEnvOrDefault[int]("SERVER_MAX_IDLE_CONNS_PER_HOST", defaultServerMaxIdleConnsPerHost)
+	config.Server.DialerTimeout = getEnvOrDefault[time.Duration]("SERVER_DIALER_TIMEOUT", defaultServerDialerTimeout)
+	config.Server.DialerKeepAlive = getEnvOrDefault[time.Duration]("SERVER_DIALER_KEEP_ALIVE", defaultServerDialerKeepAlive)
 	config.Server.HttpClientTimeout = getEnvOrDefault[time.Duration]("SERVER_HTTP_CLIENT_TIMEOUT", defaultServerHttpClientTimeout)
 	config.Server.MaxRequestBodySize = getEnvOrDefault[int64]("SERVER_MAX_REQUEST_BODY_SIZE", defaultServerMaxRequestBodySize)
 }

--- a/reframe_translator.go
+++ b/reframe_translator.go
@@ -27,14 +27,9 @@ func NewReframeTranslatorHTTPHandler(backends []*url.URL) (http.HandlerFunc, err
 }
 
 func NewReframeTranslatorService(backends []*url.URL) (*ReframeTranslatorService, error) {
-	t := http.DefaultTransport.(*http.Transport).Clone()
-	t.MaxIdleConns = config.Reframe.MaxIdleConns
-	t.MaxConnsPerHost = config.Reframe.MaxConnsPerHost
-	t.MaxIdleConnsPerHost = config.Reframe.MaxIdleConnsPerHost
-
 	httpClient := http.Client{
 		Timeout:   config.Reframe.HttpClientTimeout,
-		Transport: t,
+		Transport: reframeRoundTripper(),
 	}
 
 	clients := make([]*finderhttpclient.Client, 0, len(backends))

--- a/server.go
+++ b/server.go
@@ -53,7 +53,13 @@ func NewServer(c *cli.Context) (*server, error) {
 	t.MaxIdleConns = config.Server.MaxIdleConns
 	t.MaxConnsPerHost = config.Server.MaxConnsPerHost
 	t.MaxIdleConnsPerHost = config.Server.MaxIdleConnsPerHost
-
+	t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialer := &net.Dialer{
+			Timeout:   config.Server.DialerTimeout,
+			KeepAlive: config.Server.DialerKeepAlive,
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
 	s := server{
 		Context: c.Context,
 		Client: http.Client{


### PR DESCRIPTION
Add the ability to configure dialer timeout and keep-alive duration for reframe, reframe translator and the http server.