### PR TITLE
Cap max wait time for results and refine reframe aggregation logic

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ const (
 	defaultReframeDialerTimeout       = 10 * time.Second
 	defaultReframeDialerKeepAlive     = 15 * time.Second
 	defaultReframeHttpClientTimeout   = 10 * time.Second
+	defaultReframeResultMaxWait       = 5 * time.Second
 
 	defaultServerMaxIdleConns              = 100
 	defaultServerMaxConnsPerHost           = 100
@@ -31,6 +32,7 @@ var config struct {
 		DialerTimeout       time.Duration
 		DialerKeepAlive     time.Duration
 		HttpClientTimeout   time.Duration
+		ResultMaxWait       time.Duration
 	}
 	Server struct {
 		MaxIdleConns        int
@@ -50,6 +52,8 @@ func init() {
 	config.Reframe.DialerTimeout = getEnvOrDefault[time.Duration]("REFRAME_DIALER_TIMEOUT", defaultReframeDialerTimeout)
 	config.Reframe.DialerKeepAlive = getEnvOrDefault[time.Duration]("REFRAME_DIALER_KEEP_ALIVE", defaultReframeDialerKeepAlive)
 	config.Reframe.HttpClientTimeout = getEnvOrDefault[time.Duration]("REFRAME_HTTP_CLIENT_TIMEOUT", defaultReframeHttpClientTimeout)
+	config.Reframe.ResultMaxWait = getEnvOrDefault[time.Duration]("REFRAME_RESULT_MAX_WAIT", defaultReframeResultMaxWait)
+
 	config.Server.MaxIdleConns = getEnvOrDefault[int]("SERVER_MAX_IDLE_CONNS", defaultServerMaxIdleConns)
 	config.Server.MaxConnsPerHost = getEnvOrDefault[int]("SERVER_MAX_CONNS_PER_HOST", defaultServerMaxConnsPerHost)
 	config.Server.MaxIdleConnsPerHost = getEnvOrDefault[int]("SERVER_MAX_IDLE_CONNS_PER_HOST", defaultServerMaxIdleConnsPerHost)

--- a/reframe.go
+++ b/reframe.go
@@ -5,12 +5,12 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"sync"
 
 	"github.com/ipfs/go-cid"
 	drclient "github.com/ipfs/go-delegated-routing/client"
 	drproto "github.com/ipfs/go-delegated-routing/gen/proto"
 	drserver "github.com/ipfs/go-delegated-routing/server"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
 )
 
@@ -28,14 +28,17 @@ func NewReframeService(backends []*url.URL) (*ReframeService, error) {
 		Transport: reframeRoundTripper(),
 	}
 
-	clients := make([]drclient.DelegatedRoutingClient, 0, len(backends))
+	clients := make([]*backendDelegatedRoutingClient, 0, len(backends))
 	for _, b := range backends {
 		endpoint := b.JoinPath("reframe").String()
 		q, err := drproto.New_DelegatedRouting_Client(endpoint, drproto.DelegatedRouting_Client_WithHTTPClient(&httpClient))
 		if err != nil {
 			return nil, err
 		}
-		clients = append(clients, drclient.NewClient(q))
+		clients = append(clients, &backendDelegatedRoutingClient{
+			DelegatedRoutingClient: drclient.NewClient(q),
+			url:                    b,
+		})
 	}
 	return &ReframeService{clients}, nil
 }
@@ -56,45 +59,70 @@ func reframeRoundTripper() *http.Transport {
 }
 
 type ReframeService struct {
-	backends []drclient.DelegatedRoutingClient
+	backends []*backendDelegatedRoutingClient
+}
+
+type backendDelegatedRoutingClient struct {
+	drclient.DelegatedRoutingClient
+	url *url.URL
 }
 
 func (x *ReframeService) FindProviders(ctx context.Context, key cid.Cid) (<-chan drclient.FindProvidersAsyncResult, error) {
-	out := make(chan drclient.FindProvidersAsyncResult)
-	wg := sync.WaitGroup{}
+	sg := &scatterGather[*backendDelegatedRoutingClient, drclient.FindProvidersAsyncResult]{
+		targets: x.backends,
+		maxWait: config.Reframe.ResultMaxWait,
+	}
+
+	if err := sg.scatter(ctx, func(b *backendDelegatedRoutingClient) (<-chan drclient.FindProvidersAsyncResult, error) {
+		return b.FindProvidersAsync(ctx, key)
+	}); err != nil {
+		return nil, err
+	}
+
+	out := make(chan drclient.FindProvidersAsyncResult, 1)
 	var lastErr error
-	n := 0
-	for _, c := range x.backends {
-		childout, err := c.FindProvidersAsync(ctx, key)
-		if err != nil {
-			lastErr = err
-			continue
-		}
-		n++
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case r, ok := <-childout:
-					if !ok {
-						return
-					}
-					out <- r
-				}
-			}
-		}()
-	}
-	if n == 0 {
-		close(out)
-		return nil, lastErr
-	}
 	go func() {
-		wg.Wait()
-		close(out)
+		defer close(out)
+
+		// Aggregate any results using the following logic:
+		//
+		//  * Wait at most config.Reframe.ResultMaxWait for a result from backend.
+		//  * Only return a single result per peer ID picking the first one found.
+		//  * Do not return error if at least one provider is found.
+		//  * Return the last observed error if no providers are found.
+		//  * If no providers are found and no error has occurred return an empty
+		//    reframe result.
+		pids := make(map[peer.ID]struct{})
+		for r := range sg.gather(ctx) {
+			if r.Err != nil {
+				lastErr = r.Err
+				continue
+			}
+
+			var result drclient.FindProvidersAsyncResult
+			for _, ai := range r.AddrInfo {
+				// TODO: Improve heuristic of picking which addrinfo to return by
+				//       picking the most recently seen provider instead of first
+				//       found. /provider tells us the last seen timestamp.
+				if _, seen := pids[ai.ID]; seen {
+					continue
+				}
+				pids[ai.ID] = struct{}{}
+				result.AddrInfo = append(result.AddrInfo, ai)
+			}
+			if len(result.AddrInfo) > 0 {
+				out <- result
+			}
+		}
+
+		// If nothing is found then return the last returned error, if any.
+		if len(pids) == 0 {
+			out <- drclient.FindProvidersAsyncResult{
+				Err: lastErr,
+			}
+		}
 	}()
+
 	return out, nil
 }
 

--- a/scatter_gather.go
+++ b/scatter_gather.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type scatterGather[T, R any] struct {
+	targets []T
+	start   time.Time
+	wg      sync.WaitGroup
+	out     chan R
+	maxWait time.Duration
+}
+
+func (sg *scatterGather[T, R]) scatter(ctx context.Context, forEach func(T) (<-chan R, error)) error {
+	sg.start = time.Now()
+	sg.out = make(chan R, 1)
+	for _, t := range sg.targets {
+		sg.wg.Add(1)
+		go func(target T) {
+			defer sg.wg.Done()
+
+			select {
+			case <-ctx.Done():
+				log.Errorw("context is done before completing scatter", "err", ctx.Err())
+				return
+			default:
+			}
+
+			sout, err := forEach(target)
+			if err != nil {
+				log.Errorw("failed to scatter on target", "target", target, "err", err)
+				return
+			}
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case r, ok := <-sout:
+					if !ok {
+						return
+					}
+					sg.out <- r
+				}
+			}
+		}(t)
+	}
+	go func() {
+		defer close(sg.out)
+		sg.wg.Wait()
+	}()
+	return nil
+}
+
+func (sg *scatterGather[_, R]) gather(ctx context.Context) <-chan R {
+	gout := make(chan R, 1)
+	go func() {
+		defer func() {
+			close(gout)
+			elapsed := time.Since(sg.start)
+			log.Debugw("Completed scatter gather", "elapsed", elapsed.String())
+		}()
+
+		var rerr error
+		ticker := time.NewTicker(sg.maxWait)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				log.Debugw("Maximum scatter gather wait time reached; closing off channels", "rerr", rerr)
+				return
+			case r, ok := <-sg.out:
+				if !ok {
+					log.Debugw("Gathered all scatters in time", "rerr", rerr)
+					return
+				}
+				gout <- r
+			}
+		}
+	}()
+	return gout
+}

--- a/scatter_gather_test.go
+++ b/scatter_gather_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScatterGather_GathersExpectedResults(t *testing.T) {
+	subject := scatterGather[int, string]{
+		targets: []int{1, 2, 3, 4, 5},
+		maxWait: 2 * time.Second,
+	}
+
+	ctx := context.Background()
+	err := subject.scatter(ctx, func(i int) (<-chan string, error) {
+		r := make(chan string, 1)
+		r <- fmt.Sprintf("%d fish", i)
+		return r, nil
+	})
+	require.NoError(t, err)
+
+	var gotResults []string
+	for got := range subject.gather(ctx) {
+		gotResults = append(gotResults, got)
+	}
+	require.Len(t, gotResults, 5)
+	require.Contains(t, gotResults, "1 fish")
+	require.Contains(t, gotResults, "2 fish")
+	require.Contains(t, gotResults, "3 fish")
+	require.Contains(t, gotResults, "4 fish")
+	require.Contains(t, gotResults, "5 fish")
+}
+
+func TestScatterGather_ExcludesScatterErrors(t *testing.T) {
+	subject := scatterGather[int, string]{
+		targets: []int{1, 2, 3},
+		maxWait: 2 * time.Second,
+	}
+	ctx := context.Background()
+	err := subject.scatter(ctx, func(i int) (<-chan string, error) {
+		if i == 2 {
+			return nil, errors.New("fish says no")
+		}
+		r := make(chan string, 1)
+		r <- fmt.Sprintf("%d fish", i)
+		return r, nil
+	})
+	require.NoError(t, err)
+
+	var gotResults []string
+	for got := range subject.gather(ctx) {
+		gotResults = append(gotResults, got)
+	}
+	require.Len(t, gotResults, 2)
+	require.Contains(t, gotResults, "1 fish")
+	require.Contains(t, gotResults, "3 fish")
+	require.NotContains(t, gotResults, "2 fish")
+}
+
+func TestScatterGather_DoesNotWaitLongerThanExpected(t *testing.T) {
+	subject := scatterGather[int, string]{
+		targets: []int{1},
+		maxWait: 100 * time.Millisecond,
+	}
+	ctx := context.Background()
+	err := subject.scatter(ctx, func(i int) (<-chan string, error) {
+		time.Sleep(2 * time.Second)
+		r := make(chan string, 1)
+		r <- fmt.Sprintf("%d fish", i)
+		return r, nil
+	})
+	require.NoError(t, err)
+
+	var gotResults []string
+	for got := range subject.gather(ctx) {
+		gotResults = append(gotResults, got)
+	}
+	require.Len(t, gotResults, 0)
+}
+
+func TestScatterGather_GathersNothingWhenContextIsCancelled(t *testing.T) {
+	subject := scatterGather[int, string]{
+		targets: []int{1, 2, 3},
+		maxWait: 2 * time.Second,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	cancel()
+
+	err := subject.scatter(ctx, func(i int) (<-chan string, error) {
+		r := make(chan string, 1)
+		r <- fmt.Sprintf("%d fish", i)
+		return r, nil
+	})
+	require.NoError(t, err)
+
+	var gotResults []string
+	for got := range subject.gather(ctx) {
+		gotResults = append(gotResults, got)
+	}
+	require.Len(t, gotResults, 0)
+}


### PR DESCRIPTION
Implement a reusable scatter-gather task executor which allows the caller to specify the maximum wait time for gathering results if any.

Refactor the reframe logic to use the scatter-gather executor with configurable max wait time, default of 5 seconds.

Refine the reframe aggregation logic as following:
* Wait at most `config.Reframe.ResultMaxWait` for a result from backend.
* Only return a single result per peer ID picking the first one found.
* Do not return error if at least one provider is found.
* Return the last observed error if no providers are found.
* If no providers are found and no error has occurred return an empty reframe result.

Returning an empty result is consistent with the behaviour of reframe server implementation in storetheindex.