### PR TITLE
update reframe translator to use find codepath

### DIFF
--- a/server.go
+++ b/server.go
@@ -86,7 +86,7 @@ func (s *server) Serve() chan error {
 	mux.HandleFunc("/health", s.health)
 
 	if s.translateReframe {
-		reframe, err := NewReframeTranslatorHTTPHandler(s.servers)
+		reframe, err := NewReframeTranslatorHTTPHandler(s.doFind)
 		if err != nil {
 			ec <- err
 			close(ec)


### PR DESCRIPTION
* Use same find-scatter method for reframe translator
* use request context in scatter-gather rather than context.background (may help some timeout errors)