### PR TITLE
Simplify scatter/gather

### DIFF
--- a/find.go
+++ b/find.go
@@ -51,7 +51,7 @@ func (s *server) doFind(ctx context.Context, method string, req *url.URL, body [
 	}
 
 	count := atomic.Int32{}
-	if err := sg.scatter(ctx, func(b *url.URL) (<-chan *model.FindResponse, error) {
+	if err := sg.scatter(ctx, func(cctx context.Context, b *url.URL) (<-chan *model.FindResponse, error) {
 		// Copy the URL from original request and override host/schema to point
 		// to the server.
 		endpoint := *req
@@ -61,7 +61,7 @@ func (s *server) doFind(ctx context.Context, method string, req *url.URL, body [
 
 		bodyReader := bytes.NewReader(body)
 
-		req, err := http.NewRequest(method, endpoint.String(), bodyReader)
+		req, err := http.NewRequestWithContext(cctx, method, endpoint.String(), bodyReader)
 		if err != nil {
 			log.Warnw("Failed to construct backend query", "err", err)
 			return nil, err

--- a/find.go
+++ b/find.go
@@ -51,7 +51,7 @@ func (s *server) doFind(ctx context.Context, method string, req *url.URL, body [
 	}
 
 	count := atomic.Int32{}
-	if err := sg.scatter(ctx, func(cctx context.Context, b *url.URL) (<-chan *model.FindResponse, error) {
+	if err := sg.scatter(ctx, func(cctx context.Context, b *url.URL) (**model.FindResponse, error) {
 		// Copy the URL from original request and override host/schema to point
 		// to the server.
 		endpoint := *req
@@ -86,10 +86,7 @@ func (s *server) doFind(ctx context.Context, method string, req *url.URL, body [
 			if err != nil {
 				return nil, err
 			}
-			r := make(chan *model.FindResponse, 1)
-			r <- providers
-			close(r)
-			return r, nil
+			return &providers, nil
 		case http.StatusNotFound:
 			_ = count.Add(1)
 			return nil, nil

--- a/reframe.go
+++ b/reframe.go
@@ -86,6 +86,10 @@ func (x *ReframeService) FindProviders(ctx context.Context, key cid.Cid) (<-chan
 				res.Err = r.Err
 			}
 		}
+		// don't return both results and a partial-error.
+		if len(res.AddrInfo) != 0 {
+			res.Err = nil
+		}
 		return &res, nil
 	}); err != nil {
 		return nil, err

--- a/reframe.go
+++ b/reframe.go
@@ -73,8 +73,8 @@ func (x *ReframeService) FindProviders(ctx context.Context, key cid.Cid) (<-chan
 		maxWait: config.Reframe.ResultMaxWait,
 	}
 
-	if err := sg.scatter(ctx, func(b *backendDelegatedRoutingClient) (<-chan drclient.FindProvidersAsyncResult, error) {
-		return b.FindProvidersAsync(ctx, key)
+	if err := sg.scatter(ctx, func(cctx context.Context, b *backendDelegatedRoutingClient) (<-chan drclient.FindProvidersAsyncResult, error) {
+		return b.FindProvidersAsync(cctx, key)
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* make sure all channels are drained in cases where context is canceled.
* simplify the interface to scatter/gather - timing is on contexts, rather than on gather stopping returning.